### PR TITLE
Support to set region

### DIFF
--- a/lib/microsoft_computer_vision/api/analyze.rb
+++ b/lib/microsoft_computer_vision/api/analyze.rb
@@ -10,8 +10,8 @@ module MicrosoftComputerVision::Api
       @details = details
     end
 
-    def uri
-      uri = URI("#{MicrosoftComputerVision::Client::API_BASE}#{ENDPOINT}")
+    def uri(api_base_url)
+      uri = URI("#{api_base_url}#{ENDPOINT}")
       uri.query = URI.encode_www_form(params)
 
       uri

--- a/lib/microsoft_computer_vision/api/describe.rb
+++ b/lib/microsoft_computer_vision/api/describe.rb
@@ -9,8 +9,8 @@ module MicrosoftComputerVision::Api
       @max_candidates = max_candidates
     end
 
-    def uri
-      uri = URI("#{MicrosoftComputerVision::Client::API_BASE}#{ENDPOINT}")
+    def uri(api_base_url)
+      uri = URI("#{api_base_url}#{ENDPOINT}")
       uri.query = URI.encode_www_form(params)
 
       uri

--- a/lib/microsoft_computer_vision/api/domain_model.rb
+++ b/lib/microsoft_computer_vision/api/domain_model.rb
@@ -9,8 +9,8 @@ module MicrosoftComputerVision::Api
       @model = model
     end
 
-    def uri
-      URI("#{MicrosoftComputerVision::Client::API_BASE}#{ENDPOINT}/#{@model}/analyze")
+    def uri(api_base_url)
+      URI("#{api_base_url}#{ENDPOINT}/#{@model}/analyze")
     end
   end
 end

--- a/lib/microsoft_computer_vision/api/domain_models.rb
+++ b/lib/microsoft_computer_vision/api/domain_models.rb
@@ -5,8 +5,8 @@ module MicrosoftComputerVision::Api
 
     ENDPOINT = '/models'
 
-    def uri
-      URI("#{MicrosoftComputerVision::Client::API_BASE}#{ENDPOINT}")
+    def uri(api_base_url)
+      URI("#{api_base_url}#{ENDPOINT}")
     end
   end
 end

--- a/lib/microsoft_computer_vision/api/ocr.rb
+++ b/lib/microsoft_computer_vision/api/ocr.rb
@@ -10,8 +10,8 @@ module MicrosoftComputerVision::Api
       @detect_orientation = detect_orientation
     end
 
-    def uri
-      uri = URI("#{MicrosoftComputerVision::Client::API_BASE}#{ENDPOINT}")
+    def uri(api_base_url)
+      uri = URI("#{api_base_url}#{ENDPOINT}")
       uri.query = URI.encode_www_form(params)
 
       uri

--- a/lib/microsoft_computer_vision/api/tag.rb
+++ b/lib/microsoft_computer_vision/api/tag.rb
@@ -5,8 +5,8 @@ module MicrosoftComputerVision::Api
 
     ENDPOINT = '/tag'
 
-    def uri
-      URI("#{MicrosoftComputerVision::Client::API_BASE}#{ENDPOINT}")
+    def uri(api_base_url)
+      URI("#{api_base_url}#{ENDPOINT}")
     end
   end
 end

--- a/lib/microsoft_computer_vision/api/thumbnail.rb
+++ b/lib/microsoft_computer_vision/api/thumbnail.rb
@@ -11,8 +11,8 @@ module MicrosoftComputerVision::Api
       @smart_cropping = smart_cropping
     end
 
-    def uri
-      uri = URI("#{MicrosoftComputerVision::Client::API_BASE}#{ENDPOINT}")
+    def uri(api_base_url)
+      uri = URI("#{api_base_url}#{ENDPOINT}")
       uri.query = URI.encode_www_form(params)
 
       uri

--- a/lib/microsoft_computer_vision/client.rb
+++ b/lib/microsoft_computer_vision/client.rb
@@ -1,45 +1,43 @@
 module MicrosoftComputerVision
   class Client
-
-    API_BASE = 'https://api.projectoxford.ai/vision/v1.0'
-
-    def initialize(subscription_key)
+    def initialize(subscription_key, location = "westus")
       @subscription_key = subscription_key
+      @api_base_url = "https://#{location}.api.cognitive.microsoft.com/vision/v1.0"
     end
 
     def analyze(image_path, options)
       analyze = Api::Analyze.new(options[:visual_features], options[:details])
-      post_image_path(analyze.uri, image_path)
+      post_image_path(analyze.uri(@api_base_url), image_path)
     end
 
     def describe(image_path, options)
       describe = Api::Describe.new(options[:max_candidates])
-      post_image_path(describe.uri, image_path)
+      post_image_path(describe.uri(@api_base_url), image_path)
     end
 
     def thumbnail(image_path, options)
       thumbnail = Api::Thumbnail.new(options[:width], options[:height], options[:smart_cropping])
-      post_image_path(thumbnail.uri, image_path)
+      post_image_path(thumbnail.uri(@api_base_url), image_path)
     end
 
     def domain_models
       domain_models = Api::DomainModels.new()
-      get(domain_models.uri, {}.to_json)
+      get(domain_models.uri(@api_base_url), {}.to_json)
     end
 
     def domain_model(image_path, options)
       domain_model = Api::DomainModel.new(options[:model])
-      post_image_path(domain_model.uri, image_path)
+      post_image_path(domain_model.uri(@api_base_url), image_path)
     end
 
     def ocr(image_path, options)
       ocr = Api::OCR.new(options[:language], options[:detect_orientation])
-      post_image_path(ocr.uri, image_path)
+      post_image_path(ocr.uri(@api_base_url), image_path)
     end
 
     def tag(image_path)
       tag = Api::Tag.new()
-      post_image_path(tag.uri, image_path)
+      post_image_path(tag.uri(@api_base_url), image_path)
     end
 
     private

--- a/spec/microsoft_computer_vision/client_spec.rb
+++ b/spec/microsoft_computer_vision/client_spec.rb
@@ -15,17 +15,17 @@ RSpec.describe MicrosoftComputerVision::Client do
 
   context 'analyze' do
     it 'When image url' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/analyze').
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/analyze').
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.analyze(image_url, {})
     end
 
     it 'When image file path' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/analyze').
-          with(body: image_file_data,
-               headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/analyze').
+        with(body: image_file_data,
+             headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.analyze(image_file_path, {})
     end
@@ -33,9 +33,9 @@ RSpec.describe MicrosoftComputerVision::Client do
     it 'When options' do
       visual_features = 'visualFeatures'
       details = 'details'
-      stub_request(:post, "https://api.projectoxford.ai/vision/v1.0/analyze?visualFeatures=#{visual_features}&details=#{details}").
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, "https://westus.api.cognitive.microsoft.com/vision/v1.0/analyze?visualFeatures=#{visual_features}&details=#{details}").
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.analyze(image_url, {visual_features: visual_features, details: details})
     end
@@ -43,26 +43,26 @@ RSpec.describe MicrosoftComputerVision::Client do
 
   context 'describe' do
     it 'When image url' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/describe').
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/describe').
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.describe(image_url, {})
     end
 
     it 'When image file path' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/describe').
-          with(body: image_file_data,
-               headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/describe').
+        with(body: image_file_data,
+             headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.describe(image_file_path, {})
     end
 
     it 'When options' do
       max_candidates = '1'
-      stub_request(:post, "https://api.projectoxford.ai/vision/v1.0/describe?maxCandidates=#{max_candidates}").
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, "https://westus.api.cognitive.microsoft.com/vision/v1.0/describe?maxCandidates=#{max_candidates}").
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.describe(image_url, {max_candidates: max_candidates})
     end
@@ -70,17 +70,17 @@ RSpec.describe MicrosoftComputerVision::Client do
 
   context 'thumbnail' do
     it 'When image url' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/generateThumbnail').
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/generateThumbnail').
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.thumbnail(image_url, {})
     end
 
     it 'When image file path' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/generateThumbnail').
-          with(body: image_file_data,
-               headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/generateThumbnail').
+        with(body: image_file_data,
+             headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.thumbnail(image_file_path, {})
     end
@@ -89,9 +89,9 @@ RSpec.describe MicrosoftComputerVision::Client do
       width = 400
       height = 400
       smart_cropping = false
-      stub_request(:post, "https://api.projectoxford.ai/vision/v1.0/generateThumbnail?width=#{width}&height=#{height}&smartCropping=#{smart_cropping}").
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, "https://westus.api.cognitive.microsoft.com/vision/v1.0/generateThumbnail?width=#{width}&height=#{height}&smartCropping=#{smart_cropping}").
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.thumbnail(image_url, {width: width, height: height, smart_cropping: smart_cropping})
     end
@@ -99,17 +99,17 @@ RSpec.describe MicrosoftComputerVision::Client do
 
   context 'ocr' do
     it 'When image url' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/ocr').
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/ocr').
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.ocr(image_url, {})
     end
 
     it 'When image file path' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/ocr').
-          with(body: image_file_data,
-               headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/ocr').
+        with(body: image_file_data,
+             headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.ocr(image_file_path, {})
     end
@@ -117,9 +117,9 @@ RSpec.describe MicrosoftComputerVision::Client do
     it 'When options' do
       language = 'ja'
       detect_orientation = false
-      stub_request(:post, "https://api.projectoxford.ai/vision/v1.0/ocr?language=#{language}&detectOrientation=#{detect_orientation}").
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, "https://westus.api.cognitive.microsoft.com/vision/v1.0/ocr?language=#{language}&detectOrientation=#{detect_orientation}").
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.ocr(image_url, {language: language, detect_orientation: detect_orientation})
     end
@@ -129,17 +129,17 @@ RSpec.describe MicrosoftComputerVision::Client do
     let(:model) { 'model' }
 
     it 'When image url' do
-      stub_request(:post, "https://api.projectoxford.ai/vision/v1.0/models/#{model}/analyze").
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, "https://westus.api.cognitive.microsoft.com/vision/v1.0/models/#{model}/analyze").
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.domain_model(image_url, {model: model})
     end
 
     it 'When image file path' do
-      stub_request(:post, "https://api.projectoxford.ai/vision/v1.0/models/#{model}/analyze").
-          with(body: image_file_data,
-               headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, "https://westus.api.cognitive.microsoft.com/vision/v1.0/models/#{model}/analyze").
+        with(body: image_file_data,
+             headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.domain_model(image_file_path, {model: model})
     end
@@ -149,17 +149,17 @@ RSpec.describe MicrosoftComputerVision::Client do
     let(:model) { 'model' }
 
     it 'When image url' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/tag').
-          with(body: {url:image_url},
-               headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/tag').
+        with(body: {url:image_url},
+             headers: {'Content-Type': content_type_json, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.tag(image_url)
     end
 
     it 'When image file path' do
-      stub_request(:post, 'https://api.projectoxford.ai/vision/v1.0/tag').
-          with(body: image_file_data,
-               headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:post, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/tag').
+        with(body: image_file_data,
+             headers: {'Content-Type': content_type_stream, 'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.tag(image_file_path)
     end
@@ -167,15 +167,15 @@ RSpec.describe MicrosoftComputerVision::Client do
 
   context 'domain_models' do
     it 'When image url' do
-      stub_request(:get, 'https://api.projectoxford.ai/vision/v1.0/models').
-          with(headers: {'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:get, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/models').
+        with(headers: {'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.domain_models
     end
 
     it 'When image file path' do
-      stub_request(:get, 'https://api.projectoxford.ai/vision/v1.0/models').
-          with(headers: {'Ocp-Apim-Subscription-Key': subscription_key})
+      stub_request(:get, 'https://westus.api.cognitive.microsoft.com/vision/v1.0/models').
+        with(headers: {'Ocp-Apim-Subscription-Key': subscription_key})
 
       client.domain_models
     end


### PR DESCRIPTION
It looks like Computer Vision API v1.0 now supports some regions.

https://westus.dev.cognitive.microsoft.com/docs/services/56f91f2d778daf23d8ec6739/operations/56f91f2e778daf14a499e1fa

```
This API is currently available in:

West US - westus.api.cognitive.microsoft.com
East US 2 - eastus2.api.cognitive.microsoft.com
West Central US - westcentralus.api.cognitive.microsoft.com
West Europe - westeurope.api.cognitive.microsoft.com
Southeast Asia - southeastasia.api.cognitive.microsoft.com
```

I added support for these regions.